### PR TITLE
tree-sitter upgrade: 0.20.6 to 0.21.0

### DIFF
--- a/native/ex_tree_sitter/Cargo.lock
+++ b/native/ex_tree_sitter/Cargo.lock
@@ -13,12 +13,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
 
 [[package]]
 name = "cfg-if"
@@ -33,7 +30,7 @@ dependencies = [
  "cc",
  "rustler",
  "thiserror",
- "tree-sitter 0.20.10",
+ "tree-sitter 0.21.0",
  "tree-sitter-css",
  "tree-sitter-elixir",
  "tree-sitter-embedded-template",
@@ -57,12 +54,6 @@ name = "inventory"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
-
-[[package]]
-name = "libc"
-version = "0.2.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -100,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -112,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -129,9 +120,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustler"
@@ -210,23 +201,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705bf7c0958d0171dd7d3a6542f2f4f21d87ed5f1dc8db52919d3a6bed9a359a"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
 name = "tree-sitter-css"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44fce8f9b603fef51e6384e2771ec5448bca1b71f1aa4ee2717a1803f9b279b"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter 0.21.0",
 ]
 
 [[package]]
 name = "tree-sitter-elixir"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9916f3e1c80b3c8aab8582604e97e8720cb9b893489b347cf999f80f9d469e"
+checksum = "df94bf7f057768b1cab2ee1f14812ed4ae33f9e04d09254043eeaa797db4ef70"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter 0.21.0",
 ]
 
 [[package]]
@@ -236,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33817ade928c73a32d4f904a602321e09de9fc24b71d106f3b4b3f8ab30dcc38"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter 0.21.0",
 ]
 
 [[package]]
@@ -260,12 +261,12 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-html"
-version = "0.19.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184e6b77953a354303dc87bf5fe36558c83569ce92606e7b382a0dc1b7443443"
+checksum = "8766b5ad3721517f8259e6394aefda9c686aebf7a8c74ab8624f2c3b46902fd5"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter 0.21.0",
 ]
 
 [[package]]

--- a/native/ex_tree_sitter/Cargo.toml
+++ b/native/ex_tree_sitter/Cargo.toml
@@ -25,14 +25,14 @@ typescript = ["tree-sitter-typescript"]
 
 [dependencies]
 rustler = { version = "0.35.0", features = ["nif_version_2_17"] }
-tree-sitter = "0.20.10"
+tree-sitter = "0.21.0"
 thiserror = "1.0"
 tree-sitter-css = { version = "0.19.0", optional = true }
-tree-sitter-elixir = { version = "0.1.0", optional = true }
+tree-sitter-elixir = { version = "0.2.0", optional = true }
 tree-sitter-embedded-template = { version = "0.20.0", optional = true }
 tree-sitter-erlang = { version = "0.2.0", optional = true }
 tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam.git", version = "0.30.4", optional = true }
-tree-sitter-html = { version = "0.19.0", optional = true }
+tree-sitter-html = { version = "0.20.3", optional = true }
 tree-sitter-javascript = { version = "0.20.1", optional = true }
 tree-sitter-json = { version = "0.20.1", optional = true }
 tree-sitter-sql = { version = "0.0.2", optional = true }

--- a/native/ex_tree_sitter/src/language.rs
+++ b/native/ex_tree_sitter/src/language.rs
@@ -161,9 +161,9 @@ fn html_queries() -> Vec<(Atom, &'static str)> {
     vec![
         (
             crate::atoms::highlights(),
-            tree_sitter_html::HIGHLIGHT_QUERY,
+            tree_sitter_html::HIGHLIGHTS_QUERY,
         ),
-        (crate::atoms::injection(), tree_sitter_html::INJECTION_QUERY),
+        (crate::atoms::injection(), tree_sitter_html::INJECTIONS_QUERY),
     ]
 }
 

--- a/native/ex_tree_sitter/src/parser.rs
+++ b/native/ex_tree_sitter/src/parser.rs
@@ -13,13 +13,13 @@ impl rustler::Resource for Parser {}
 impl Parser {
     pub fn new<'a>(lang: tree_sitter::Language) -> Result<Self, ParserError<'a>> {
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(lang)?;
+        parser.set_language(&lang)?;
         Ok(Self(Mutex::new(parser)))
     }
 
     pub fn set_language(&self, lang: tree_sitter::Language) -> Result<(), ParserError<'_>> {
         let mut parser = self.lock()?;
-        parser.set_language(lang)?;
+        parser.set_language(&lang)?;
         Ok(())
     }
 

--- a/native/ex_tree_sitter/src/query.rs
+++ b/native/ex_tree_sitter/src/query.rs
@@ -12,7 +12,7 @@ pub fn query_matches(
     source: &[u8],
 ) -> Result<Vec<QueryMatch>, Error<Dummy>> {
     let query_source = String::from_utf8(query_raw.to_vec())?;
-    let query = Query::new(language, &query_source)?;
+    let query = Query::new(&language, &query_source)?;
     let mut cursor = QueryCursor::new();
     Ok(cursor
         .matches(&query, tree.root_node(), source)

--- a/native/ex_tree_sitter/src/query.rs
+++ b/native/ex_tree_sitter/src/query.rs
@@ -61,7 +61,7 @@ impl QueryCapture {
         source: &[u8],
     ) -> Self {
         let capture_names = query.capture_names();
-        let capture_name = capture_names[capture.index as usize].clone();
+        let capture_name = capture_names[capture.index as usize].to_string();
         let node = Node::from_tsnode(&capture.node, Some(source));
         Self {
             node,


### PR DESCRIPTION
I originally planned to upgrade to the latest `tree-sitter` (which fixes an out-of-bounds error I came across), but there are a couple of language grammars that haven't upgraded to use `tree-sitter-language` instead. This interim upgrade will help though.

(Later `tree-sitter` language versions start depending on `tree-sitter-language` instead, with a much more stable API. So future upgrades should be easier)