### PR TITLE
update tree-sitter packages

### DIFF
--- a/native/ex_tree_sitter/Cargo.lock
+++ b/native/ex_tree_sitter/Cargo.lock
@@ -4,18 +4,21 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -29,8 +32,9 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "rustler",
+ "streaming-iterator",
  "thiserror",
- "tree-sitter 0.22.6",
+ "tree-sitter",
  "tree-sitter-css",
  "tree-sitter-elixir",
  "tree-sitter-embedded-template",
@@ -67,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
@@ -91,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -150,6 +154,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,121 +198,120 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "f9871f16d6cf5c4757dcf30d5d2172a2df6987c510c017bbb7abfb7f9aa24d06"
 dependencies = [
  "cc",
  "regex",
-]
-
-[[package]]
-name = "tree-sitter"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
-dependencies = [
- "cc",
- "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-css"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e08e324b1cf60fd3291774b49724c66de2ce8fcf4d358d0b4b82e37b41b1c9b"
+checksum = "8d0018d6b1692a806f9cddaa1e5616951fd58840c39a0b21401b55ab3df12292"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-elixir"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94bf7f057768b1cab2ee1f14812ed4ae33f9e04d09254043eeaa797db4ef70"
+checksum = "97bf0efa4be41120018f23305b105ad4dfd3be1b7f302dc4071d0e6c2dec3a32"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-embedded-template"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33817ade928c73a32d4f904a602321e09de9fc24b71d106f3b4b3f8ab30dcc38"
+checksum = "9644d7586ebe850c84037ee2f4804dda4a9348eef053be6b1e0d7712342a2495"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-erlang"
-version = "0.5.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5fed9d3cb6c7530e1119782637dfaf665192de078b9a8c3d1913f6a1a87fe7"
+checksum = "489bf4fed178fc0192ef47bf4570225558723952b8c88233704fd91445b45a8e"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-gleam"
-version = "0.30.4"
-source = "git+https://github.com/gleam-lang/tree-sitter-gleam.git#32c8f1e32aee036583ca09e7e6e4ea881852b42c"
+version = "1.0.0"
+source = "git+https://github.com/gleam-lang/tree-sitter-gleam.git#57c9951b290c8084d7c60b0aee7a2b30986ea031"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-html"
-version = "0.20.4"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8766b5ad3721517f8259e6394aefda9c686aebf7a8c74ab8624f2c3b46902fd5"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.21.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8710a71bc6779e33811a8067bdda3ed08bed1733296ff915e44faf60f8c533d7"
+checksum = "59e1f62f8babb640b909f30675d1addeb1f17802f2a4d2af287569753b243977"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-json"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d82d2e33ee675dc71289e2ace4f8f9cf96d36d81400e9dae5ea61edaf5dea6"
+checksum = "86a5d6b3ea17e06e7a34aabeadd68f5866c0d0f9359155d432095f8b751865e4"
 dependencies = [
  "cc",
- "tree-sitter 0.20.10",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-sequel"
-version = "0.3.5"
+name = "tree-sitter-language"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e39194c44ad71033d8b09d225c03e154dee9b788c6a113bce7feb809f39480f"
+checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b40eae724945161b8a26347740a8db4ad815ee98c8c2d99a122db9dd763f1f"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.21.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
+checksum = "aecf1585ae2a9dddc2b1d4c0e2140b2ec9876e2a25fd79de47fcf7dae0384685"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/native/ex_tree_sitter/Cargo.toml
+++ b/native/ex_tree_sitter/Cargo.toml
@@ -25,18 +25,19 @@ typescript = ["tree-sitter-typescript"]
 
 [dependencies]
 rustler = { version = "0.35.0", features = ["nif_version_2_17"] }
-tree-sitter = "0.22.0"
+streaming-iterator = "0.1.9"
 thiserror = "1.0"
-tree-sitter-css = { version = "0.21.0", optional = true }
-tree-sitter-elixir = { version = "0.2.0", optional = true }
-tree-sitter-embedded-template = { version = "0.20.0", optional = true }
-tree-sitter-erlang = { version = "0.5.0", optional = true }
-tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam.git", version = "0.30.4", optional = true }
-tree-sitter-html = { version = "0.20.3", optional = true }
-tree-sitter-javascript = { version = "0.21.2", optional = true }
-tree-sitter-json = { version = "0.20.1", optional = true }
-tree-sitter-sequel = { version = "0.3.5", optional = true }
-tree-sitter-typescript = { version = "0.21.2", optional = true }
+tree-sitter = "0.24.3"
+tree-sitter-css = { version = "0.23.0", optional = true }
+tree-sitter-elixir = { version = "0.3.1", optional = true }
+tree-sitter-embedded-template = { version = "0.23.0", optional = true }
+tree-sitter-erlang = { version = "0.9.0", optional = true }
+tree-sitter-gleam = { git = "https://github.com/gleam-lang/tree-sitter-gleam.git", version = "1.0.0", optional = true }
+tree-sitter-html = { version = "0.23.1", optional = true }
+tree-sitter-javascript = { version = "0.23.0", optional = true }
+tree-sitter-json = { version = "0.23.0", optional = true }
+tree-sitter-sequel = { version = "0.3.7" , optional = true }
+tree-sitter-typescript = { version = "0.23.0", optional = true }
 
 [build-dependencies]
 cc = "*"

--- a/native/ex_tree_sitter/src/language.rs
+++ b/native/ex_tree_sitter/src/language.rs
@@ -71,26 +71,26 @@ macro_rules! impl_get_lang {
     };
 }
 
-impl_get_lang!(get_css, "css", tree_sitter_css::language());
-impl_get_lang!(get_elixir, "elixir", tree_sitter_elixir::language());
+impl_get_lang!(get_css, "css", tree_sitter_css::LANGUAGE.into());
+impl_get_lang!(get_elixir, "elixir", tree_sitter_elixir::LANGUAGE.into());
 impl_get_lang!(
     get_embedded_template,
     "embedded-template",
-    tree_sitter_embedded_template::language()
+    tree_sitter_embedded_template::LANGUAGE.into()
 );
-impl_get_lang!(get_erlang, "erlang", tree_sitter_erlang::language());
-impl_get_lang!(get_gleam, "gleam", tree_sitter_gleam::language());
-impl_get_lang!(get_html, "html", tree_sitter_html::language());
+impl_get_lang!(get_erlang, "erlang", tree_sitter_erlang::LANGUAGE.into());
+impl_get_lang!(get_gleam, "gleam", tree_sitter_gleam::LANGUAGE.into());
+impl_get_lang!(get_html, "html", tree_sitter_html::LANGUAGE.into());
 impl_get_lang!(
     get_javascript,
     "javascript",
-    tree_sitter_javascript::language()
+    tree_sitter_javascript::LANGUAGE.into()
 );
-impl_get_lang!(get_sql, "sql", tree_sitter_sequel::language());
+impl_get_lang!(get_sql, "sql", tree_sitter_sequel::LANGUAGE.into());
 impl_get_lang!(
     get_typescript,
     "typescript",
-    tree_sitter_typescript::language()
+    tree_sitter_typescript::LANGUAGE.into()
 );
 
 #[cfg(feature = "css")]
@@ -126,7 +126,7 @@ fn elixir_queries() -> Vec<(Atom, &'static str)> {
 fn embedded_template_queries() -> Vec<(Atom, &'static str)> {
     vec![(
         crate::atoms::highlights(),
-        tree_sitter_embedded_template::HIGHLIGHT_QUERY,
+        tree_sitter_embedded_template::HIGHLIGHTS_QUERY,
     )]
 }
 
@@ -177,7 +177,7 @@ fn javascript_queries() -> Vec<(Atom, &'static str)> {
     vec![
         (
             crate::atoms::highlights(),
-            tree_sitter_javascript::HIGHLIGHT_QUERY,
+            tree_sitter_javascript::HIGHLIGHTS_QUERY,
         ),
         (
             crate::atoms::injection(),
@@ -185,7 +185,7 @@ fn javascript_queries() -> Vec<(Atom, &'static str)> {
         ),
         (
             crate::atoms::jsx(),
-            tree_sitter_javascript::JSX_HIGHLIGHT_QUERY,
+            tree_sitter_javascript::JSX_HIGHLIGHTS_QUERY,
         ),
         (crate::atoms::locals(), tree_sitter_javascript::LOCALS_QUERY),
         (crate::atoms::tags(), tree_sitter_javascript::TAGGING_QUERY),
@@ -206,7 +206,7 @@ fn typescript_queries() -> Vec<(Atom, &'static str)> {
     vec![
         (
             crate::atoms::highlights(),
-            tree_sitter_typescript::HIGHLIGHT_QUERY,
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
         ),
         (crate::atoms::locals(), tree_sitter_typescript::LOCALS_QUERY),
         (crate::atoms::tags(), tree_sitter_typescript::TAGGING_QUERY),


### PR DESCRIPTION
After some recent `tree-sitter-*` upgrades, we now depend on `tree-sitter-language` instead.

Also includes:
- `language` becomes `LANGUAGE.into()`
- some renaming of `HIGHLIGHTS?_QUERY` across packages
- upgrade `tree-sitter` to 0.24.3
- rework `query_matches`. Since `matches` now returns a streaming iterator, we have to loop rather than use `map`